### PR TITLE
Markdown needs to be wrapped under ticks

### DIFF
--- a/fix-readme-markdown
+++ b/fix-readme-markdown
@@ -11,7 +11,7 @@ npm install gatsby-remark-video
 
 In your markdown
 ```
-video: /static/shots-demo-369bfe714a6b8981ecfc743f7e7e7008.mp4
+`video: /static/shots-demo-369bfe714a6b8981ecfc743f7e7e7008.mp4`
 ```
 
 Add the following in your `gatsby-config.js`


### PR DESCRIPTION
The example in the readme does not work for me if I don't wrap
```
video: /static/shots-demo-369bfe714a6b8981ecfc743f7e7e7008.mp4
```

in ticks

```
`video: /static/shots-demo-369bfe714a6b8981ecfc743f7e7e7008.mp4`
```