### PR TITLE
Support for multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ npm install gatsby-remark-video
 
 In your markdown
 ```
-`video: /static/shots-demo-369bfe714a6b8981ecfc743f7e7e7008.mp4`
+`video: /shots-demo-369bfe714a6b8981ecfc743f7e7e7008.mp4`
+```
+
+For adding multiple sources, ensure the urls are separated by the `|` character
+
+```
+`video: https://interactive-examples.mdn.mozilla.net/media/examples/flower.webm|https://interactive-examples.mdn.mozilla.net/media/examples/flower.mp4`
+```
+
+```
+`video: /flower.webm|/flower.mp4`
 ```
 
 Add the following in your `gatsby-config.js`

--- a/index.js
+++ b/index.js
@@ -1,24 +1,24 @@
 const visit = require('unist-util-visit');
 
 const addVideo = ({ markdownAST }, options) => {
-
+  
 	visit(markdownAST, 'inlineCode', (node) => {
-		const { value } = node;
-		const matches = value.match(/video:?\s(.*)+/i);
+    const { value } = node;
+    const matches = value.match(/video:?\s(.*)+/i);
 
-		if(matches) {
-			const url = matches[1].trim();
+    if(matches) {
+      const url = matches[1].trim();
 
-			node.type = 'html';
-			node.value = renderVideoTag(url, options);
-		}
-	});
+      node.type = 'html';
+      node.value = renderVideoTag(url, options);
+    }
+  });
 
 };
 
 const renderVideoTag = (url, options) => {
 
-	const videoNode = `
+  const videoNode = `
 		<video
 			src=${url}
 			width="${options.width}"
@@ -31,7 +31,22 @@ const renderVideoTag = (url, options) => {
 		></video>
 	`;
 
-	return videoNode;
+  return videoNode;
+};
+
+const getMimeType = extension => {
+  switch (extension) {
+    case 'mp4':
+      return 'mp4';
+    case 'ogg':
+      return 'ogg';
+    case 'ogv':
+      return 'ogg';
+    case 'webm':
+      return 'webm';
+    default:
+      return '';
+  }
 };
 
 module.exports = addVideo;


### PR DESCRIPTION
Sometimes a codec may not be supported by a browser. This PR adds the feature to add multiple sources allowing to watch a video regardless of which video codecs are supported by the browser.