### PR TITLE
Add support for video titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ In your markdown
 `video: /static/shots-demo-369bfe714a6b8981ecfc743f7e7e7008.mp4`
 ```
 
+You can also add a title to the video tag by adding it in your markdown
+
+```
+`video: title: "Short demo": /static/shots-demo-369bfe714a6b8981ecfc743f7e7e7008.mp4`
+```
+
+Keep in mind that you need double quotes in order to title a video.
+You can also escape a double quote the way you might expect:
+```
+`video: title: "Short \"demo\"": /static/shots-demo-369bfe714a6b8981ecfc743f7e7e7008.mp4`
+```
+ 
 Add the following in your `gatsby-config.js`
 ```javascript
 {

--- a/index.js
+++ b/index.js
@@ -1,16 +1,36 @@
 const visit = require('unist-util-visit');
 
-const addVideo = ({ markdownAST }, options) => {
+const matchRegExp = new RegExp(
+	// Look for a "video" and then possibly ':' and then a space
+	`video:?\\s` +
+	// Then, optionally find "title" and then possible :
+	`(?:title:?\\s"(` +
+	// '.*?(?!\\").' is a trick to negative lookbehind (since negative look-behinds have poor node support for now)
+	// It allows us to be a able to get "any \"escaped\" quoted value" but lazily to avoid grabbing too much
+	`.*?(?!\\\\").)"` +
+	// The : is optional much like with 'video', but the title itself is also optional entirely
+	`:?\\s)?` +
+	// Then grab the video path from the string
+	`(.*)`,
+	// Make it insensitive
+	'i'
+);
+
+const addVideo = ({markdownAST}, options) => {
 
 	visit(markdownAST, 'inlineCode', (node) => {
-		const { value } = node;
-		const matches = value.match(/video:?\s(.*)+/i);
+		const {value} = node;
+		const matches = value.match(matchRegExp);
 
-		if(matches) {
-			const url = matches[1].trim();
+		if (matches) {
+			const title = matches[1]; // May be null
+			const url = matches[2].trim();
 
 			node.type = 'html';
-			node.value = renderVideoTag(url, options);
+			node.value = renderVideoTag(url, {
+				...options,
+				title: title || url
+			});
 		}
 	});
 
@@ -25,6 +45,7 @@ const renderVideoTag = (url, options) => {
 			height="${options.height}"
 			preload="${options.preload}"
 			muted="${options.muted}"
+			title="${options.title}"
 			${options.autoplay ? 'autoplay' : ''}
 			${options.controls ? 'controls' : ''}
 			${options.loop ? 'loop' : ''}


### PR DESCRIPTION
One of the big concerns with this plugin from an accessability standpoint is the lack of titles for the videos themselves. This PR adds the functionality (and documentation for it) for said functionality on a per-video basis. 

This PR makes sure to break out the regex to multi-line setup in order to provide comments for some of the more complex parts of the new regex