### PR TITLE
added options: disableDownload, disablePictureInPicture

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Add the following in your `gatsby-config.js`
 		autoplay: true,
 		playsinline: true,
 		controls: true,
-		loop: true
+		loop: true,
+		disablePictureInPicture: true,
+		disableDownload: true,
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Add the following in your `gatsby-config.js`
 		playsinline: true,
 		controls: true,
 		loop: true,
-		disablePictureInPicture: true,
-		disableDownload: true,
+		disablePictureInPicture: true, // disable Chrome "Picture in Picture" feature
+		disableDownload: true, // disable Chrome "Download" feature
 	}
 }
 ```

--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ const renderVideoTag = (url, options) => {
 			${options.playsinline ? 'playsinline' : ''}
 			${options.controls ? 'controls' : ''}
 			${options.loop ? 'loop' : ''}
+			${options.disablePictureInPicture ? 'disablePictureInPicture' : ''}
+			${options.disableDownload ? 'controlsList="nodownload"' : ''}
 		></video>
 	`;
 


### PR DESCRIPTION
- Added two pass-through options called disableDownload and disablePictureInPicture. These disable the equivalent features in Chrome. 

![1590669057](https://user-images.githubusercontent.com/1698456/83141417-f1a56e00-a0ef-11ea-8bad-9d14371236ed.png)

- DisablePictureInPicture has no effect on Firefox, but that is a browser limitation.

- Updated README to show usage.